### PR TITLE
Fixing support for Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.6", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/pulsectl_asyncio/pulsectl_async.py
+++ b/pulsectl_asyncio/pulsectl_async.py
@@ -14,6 +14,7 @@ import functools as ft
 from typing import Optional, AsyncIterator, Coroutine
 from contextlib import suppress
 import sys
+from warnings import warn
 
 from .pa_asyncio_mainloop import PythonMainLoop
 from pulsectl.pulsectl import (
@@ -71,6 +72,9 @@ class PulseAsync(object):
 			Specifying "connect=False" here prevents that, but be sure to call connect() later.
 			"connect=False" can also be used here to
 				have control over options passed to connect() method.'''
+		if loop:
+			warn("The parameter 'loop' is deprecated and will be removed in future versions, since it is no longer necessary", DeprecationWarning)
+
 		self.name = client_name or 'pulsectl'
 		self.server = server
 		self._connected = asyncio.Event(**({"loop": loop} if sys.version_info[:2] < (3, 8) else {}))

--- a/pulsectl_asyncio/pulsectl_async.py
+++ b/pulsectl_asyncio/pulsectl_async.py
@@ -13,6 +13,7 @@ import inspect
 import functools as ft
 from typing import Optional, AsyncIterator, Coroutine
 from contextlib import suppress
+import sys
 
 from .pa_asyncio_mainloop import PythonMainLoop
 from pulsectl.pulsectl import (
@@ -72,8 +73,8 @@ class PulseAsync(object):
 				have control over options passed to connect() method.'''
 		self.name = client_name or 'pulsectl'
 		self.server = server
-		self._connected = asyncio.Event(loop=loop)
-		self._disconnected = asyncio.Event(loop=loop)
+		self._connected = asyncio.Event(**({"loop": loop} if sys.version_info[:2] < (3, 8) else {}))
+		self._disconnected = asyncio.Event(**({"loop": loop} if sys.version_info[:2] < (3, 8) else {}))
 		self._disconnected.set()
 		self._ctx = self._loop = None
 		self.init(loop)


### PR DESCRIPTION
Due to [this asyncio commit](https://github.com/python/cpython/commit/b9127dd6eedd693cfd716a4444648864e2e00186), initializing ```PulseAsync``` now raises a ```TypeError``` (see [here](https://github.com/python/cpython/commit/b9127dd6eedd693cfd716a4444648864e2e00186#diff-e5b10943fef60b34a59e7006ba041003ed376c5e52d7ba1fa40d323b598f4063R18)).

My fix is to pass the ```loop``` parameter to ```asyncio.Event``` only in older python versions, where it was necessary.

All unit tests passed.