### PR TITLE
Fix cleanup of events in PythonMainLoop.stop()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.12"]
+        python-version: ["3.9", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -45,10 +45,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.14
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.14
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pulsectl_asyncio/pa_asyncio_mainloop.py
+++ b/pulsectl_asyncio/pa_asyncio_mainloop.py
@@ -174,7 +174,7 @@ class PythonMainLoop:
             event.read()
 
     def stop(self, retval: int) -> None:
-        for event in itertools.chain(self.defer_events, self.io_writer_events, self.time_events):
+        for event in itertools.chain(self.defer_events, self.io_events, self.time_events):
             event.free()
         self.retval = retval
 

--- a/pulsectl_asyncio/pa_asyncio_mainloop.py
+++ b/pulsectl_asyncio/pa_asyncio_mainloop.py
@@ -174,7 +174,7 @@ class PythonMainLoop:
             event.read()
 
     def stop(self, retval: int) -> None:
-        for event in itertools.chain(self.defer_events, self.io_events, self.time_events):
+        for event in itertools.chain(set(self.defer_events), set(self.io_events), set(self.time_events)):
             event.free()
         self.retval = retval
 


### PR DESCRIPTION
I applied the suggestions from the LLM analysis in #17.

However, I did not change the teardown order in `PulseAsync.close()`. Reasoning: The Pulse context is created on existing event loop. So the usual order of deconstruction is reverse: First the context, then the event loop. This is such a strong convention that I assume libpulse's C code to handle the object dependencies and freeing correctly when the context is freed while there are still pending events.